### PR TITLE
Support for exporting Maven artefact

### DIFF
--- a/auth-lib/build.gradle
+++ b/auth-lib/build.gradle
@@ -20,6 +20,12 @@
  */
 
 apply plugin: 'com.android.library'
+apply plugin: 'com.github.dcendents.android-maven'
+
+/* Maven properties */
+group = 'com.spotify.sdk'
+version = '1.0.0'
+project.archivesBaseName = 'spotify-android-auth'
 
 android {
     compileSdkVersion 24

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
 }
 


### PR DESCRIPTION
Using com.github.dcendents:android-maven-gradle-plugin
one can use "gradle install" to export a Maven artefact.