### PR TITLE
Upgrade compile & target SDK versions, build tool versions etc.,

### DIFF
--- a/auth-lib/build.gradle
+++ b/auth-lib/build.gradle
@@ -22,12 +22,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion '24.0.1'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName '1.0.0'
     }
@@ -61,7 +61,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:customtabs:24.2.1'
+    compile 'com.android.support:customtabs:25.1.1'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'


### PR DESCRIPTION
Upgrade compile and target SDK versions, build tool versions and customtabs support library versions to latest ones.

If the host app targets Android N and uses 25.+ support libraries, integrating the spotify SDK results in a crash while trying to open chrome custom tabs. Similar issues can be seen at 

[http://stackoverflow.com/questions/41564529/chrome-customtab-error-java-lang-nosuchmethoderror-no-static-method-startactiv](here) 

[http://stackoverflow.com/questions/40624768/unable-to-start-chrome-customtabsintent-in-my-android-app](here)
