### PR TITLE
Provide method to clear cookies in AuthenticationClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
     - tools
     - tools
     - platform-tools
-    - build-tools-27.0.2
+    - build-tools-27.0.3
     - android-27
     - extra-android-m2repository
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+## Version 1.1.1
+
+_2018-02-28_
+
+* Add  method to clear Spotify and Facebook cookies to AuthenticationClient
+* Upgrade buildToolsVersion to 27.0.3
+* Replace deprecated compile keyword in gradle files
+
 ## Version 1.1.0
 
 _2018-02-28_

--- a/auth-lib/build.gradle
+++ b/auth-lib/build.gradle
@@ -23,11 +23,11 @@ apply plugin: 'com.android.library'
 
 project.group = 'com.spotify.android'
 project.archivesBaseName = 'auth'
-project.version = '1.1.0'
+project.version = '1.1.1'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.2'
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 15
@@ -63,11 +63,11 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:customtabs:27.0.2'
+    api 'com.android.support:customtabs:27.0.2'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.12.0'
-    testCompile 'org.robolectric:robolectric:3.5.1'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.12.0'
+    testImplementation 'org.robolectric:robolectric:3.5.1'
 }
 
 /*

--- a/auth-lib/build.gradle
+++ b/auth-lib/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 
 dependencies {
-    api 'com.android.support:customtabs:27.0.2'
+    implementation 'com.android.support:customtabs:27.0.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.12.0'

--- a/auth-lib/src/main/java/com/spotify/sdk/android/authentication/AuthenticationClient.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/authentication/AuthenticationClient.java
@@ -329,6 +329,17 @@ public class AuthenticationClient {
     }
 
     /**
+     * Helper method to clear any Spotify and Facebook cookies from the WebView browser.
+     * <p>
+     * Calling this method will not affect the validity of the obtained access tokens and current Player session.
+     *
+     * @param context Android context.
+     */
+    public static void clearCookies(Context context) {
+        LoginDialog.clearCookies(context);
+    }
+
+    /**
      * Extracts {@link com.spotify.sdk.android.authentication.AuthenticationResponse}
      * from the LoginActivity result.
      *

--- a/auth-lib/src/main/java/com/spotify/sdk/android/authentication/LoginDialog.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/authentication/LoginDialog.java
@@ -248,4 +248,13 @@ class LoginDialog extends Dialog {
         LinearLayout layout = (LinearLayout) findViewById(R.id.com_spotify_sdk_login_webview_container);
         layout.setLayoutParams(new FrameLayout.LayoutParams(dialogWidth, dialogHeight, Gravity.CENTER));
     }
+
+    static void clearCookies(Context context) {
+        WebViewUtils.clearFacebookCookies(context);
+
+        WebViewUtils.clearCookiesForDomain(context, "spotify.com");
+        WebViewUtils.clearCookiesForDomain(context, ".spotify.com");
+        WebViewUtils.clearCookiesForDomain(context, "https://spotify.com");
+        WebViewUtils.clearCookiesForDomain(context, "https://.spotify.com");
+    }
 }

--- a/auth-lib/src/main/java/com/spotify/sdk/android/authentication/WebViewUtils.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/authentication/WebViewUtils.java
@@ -1,0 +1,49 @@
+package com.spotify.sdk.android.authentication;
+
+import android.content.Context;
+import android.webkit.CookieManager;
+import android.webkit.CookieSyncManager;
+
+/*
+ * The methods in this class come from com.facebook.internal.Utility class
+ * in Facebook SDK for Android v3.23.0
+ * *
+ * Public repository URL: https://github.com/facebook/facebook-android-sdk
+ * Commit ID: 6b9427d160daa746b84b769c16a9c9e4d9969936
+ * File path: facebook/src/com/facebook/internal/Utility.java
+ */
+class WebViewUtils {
+
+    static void clearFacebookCookies(Context context) {
+        // setCookie acts differently when trying to expire cookies between builds of Android that are using
+        // Chromium HTTP stack and those that are not. Using both of these domains to ensure it works on both.
+        clearCookiesForDomain(context, "facebook.com");
+        clearCookiesForDomain(context, ".facebook.com");
+        clearCookiesForDomain(context, "https://facebook.com");
+        clearCookiesForDomain(context, "https://.facebook.com");
+    }
+
+    static void clearCookiesForDomain(Context context, String domain) {
+        // This is to work around a bug where CookieManager may fail to instantiate if CookieSyncManager
+        // has never been created.
+        CookieSyncManager syncManager = CookieSyncManager.createInstance(context);
+        syncManager.sync();
+
+        CookieManager cookieManager = CookieManager.getInstance();
+
+        String cookies = cookieManager.getCookie(domain);
+        if (cookies == null) {
+            return;
+        }
+
+        String[] splitCookies = cookies.split(";");
+        for (String cookie : splitCookies) {
+            String[] cookieParts = cookie.split("=");
+            if (cookieParts.length > 0) {
+                String newCookie = cookieParts[0].trim() + "=;expires=Sat, 1 Jan 2000 00:00:01 UTC;";
+                cookieManager.setCookie(domain, newCookie);
+            }
+        }
+        cookieManager.removeExpiredCookie();
+    }
+}

--- a/auth-sample/build.gradle
+++ b/auth-sample/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.2"
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.spotify.sdk.android.authentication.sample"
@@ -53,9 +53,9 @@ android {
 }
 
 dependencies {
-    compile 'com.spotify.android:auth:1.1.0'
+    implementation 'com.spotify.android:auth:1.1.0'
 
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.android.support:design:27.0.2'
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:design:27.0.2'
+    implementation 'com.squareup.okhttp3:okhttp:3.4.1'
 }


### PR DESCRIPTION
SDK users would like to have a method to clear cookies in case they want to re-authenticate with a different app user.

**Changes in this PR:**
- Bump project version to `1.1.1`

- Add  method to clear Spotify and Facebook cookies to `AuthenticationClient`

- Upgrade `buildToolsVersion` to `27.0.3`

- Replace deprecated `compile` keyword in gradle files