### PR TITLE
Update README library directive to use implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ that can subsequently be used to play music or in requests to the [Spotify Web A
 To add this library to your project add the reference to its `build.gradle` file:
 
 ```gradle
-compile 'com.spotify.android:auth:1.2.3'
+implementation "com.spotify.android:auth:1.2.3"
 ```
 
 To learn more about working with authentication see the


### PR DESCRIPTION
`compile` gradle configuration has been deprecated since a while. Let's switch to `implementation`.