### PR TITLE
Handle orientation change in LoginActivity

### DIFF
--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/LoginActivity.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/LoginActivity.java
@@ -109,7 +109,7 @@ public class LoginActivity extends Activity implements AuthorizationClient.Autho
             Log.e(TAG, NO_REQUEST_ERROR);
             setResult(Activity.RESULT_CANCELED);
             finish();
-        } else {
+        } else if (savedInstanceState == null) {
             Log.d(TAG, String.format("Spotify Auth starting with the request [%s]", request.toUri().toString()));
             mAuthorizationClient.authorize(request);
         }


### PR DESCRIPTION
Fixes issue where Spotify login screen would be retriggered twice in the following scenario:
1, `AuthorizationClient.openLoginActivity(...)` is called, which opens Spotify login screen
2, User rotates screen
3, User clicks back button
In this scenario, Spotify login screen would be shown again