### PR TITLE
Migrate auth-lib from JCenter to MavenCentral

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Spotify Authentication Library
 
+[![Maven Central](https://img.shields.io/maven-central/v/com.spotify.android/auth.svg)](https://search.maven.org/search?q=g:com.spotify.android)
+
 # This repository is now a part of [spotify/android-sdk](https://github.com/spotify/android-sdk). Please post new issues there!
 
 This library is responsible for authenticating the user and fetching the access token
@@ -10,7 +12,7 @@ that can subsequently be used to play music or in requests to the [Spotify Web A
 To add this library to your project add the reference to its `build.gradle` file:
 
 ```gradle
-implementation "com.spotify.android:auth:1.2.3"
+implementation "com.spotify.android:auth:<version>"
 ```
 
 Since April 2021 we're publishing library on MavenCentral instead of JCenter. Therefore to be able to get the library dependency, you should add MavenCentral into repositories block:

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ To add this library to your project add the reference to its `build.gradle` file
 implementation "com.spotify.android:auth:<version>"
 ```
 
-Since April 2021 we're publishing library on MavenCentral instead of JCenter. Therefore to be able to get the library dependency, you should add MavenCentral into repositories block:
+Since April 2021 we'll be publishing the library on MavenCentral instead of JCenter. Therefore to be able to get the library dependency, you should add MavenCentral into repositories block:
 ```gradle
 repositories {
-        mavenCentral()
-        ...
-    }
+    mavenCentral()
+    ...
+}
 ```
 
 To learn more about working with authentication see the

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ To add this library to your project add the reference to its `build.gradle` file
 implementation "com.spotify.android:auth:1.2.3"
 ```
 
+Since April 2021 we're publishing library on MavenCentral instead of JCenter. Therefore to be able to get the library dependency, you should add MavenCentral into repositories block:
+```gradle
+repositories {
+        mavenCentral()
+        ...
+    }
+```
+
 To learn more about working with authentication see the
 [Authentication Guide](https://developer.spotify.com/technologies/spotify-android-sdk/android-sdk-authentication-guide/)
 and the [API reference](https://developer.spotify.com/android-sdk-docs/authentication) on the developer site.

--- a/auth-lib/build.gradle
+++ b/auth-lib/build.gradle
@@ -108,13 +108,12 @@ artifacts {
     archives sourcesJar
 }
 
-signing {
-    sign configurations.archives
+if (signingEnabled == "true") {
+    signing {
+        sign configurations.archives
+    }
 }
 
-project.ext["signing.keyId"] = ''
-project.ext["signing.password"] = ''
-project.ext["signing.secretKeyRingFile"] = ''
 project.ext["ossrhUsername"] = ''
 project.ext["ossrhPassword"] = ''
 
@@ -131,9 +130,6 @@ def getSigningVariables() {
             project.ext[name] = value
         }
     } else {
-        project.ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
-        project.ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
-        project.ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
         project.ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
         project.ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
     }
@@ -141,7 +137,7 @@ def getSigningVariables() {
 
 /*
     Deployment to OSSRH repository
-    1. run: ./gradlew uploadArchives
+    1. run: ./gradlew uploadArchives -PsigningEnabled=true
     2. login to https://s01.oss.sonatype.org/ (you need to have access to auth lib OSSRH repository)
     3. if everything looks correctly, close and then release the staging repository.
     More info here: https://central.sonatype.org/publish/release/

--- a/auth-lib/build.gradle
+++ b/auth-lib/build.gradle
@@ -81,8 +81,8 @@ task checkstyle(type: Checkstyle) {
     classpath = files()
 }
 
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven'
+apply plugin: 'signing'
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
@@ -92,7 +92,8 @@ task sourcesJar(type: Jar) {
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    options.links("http://docs.oracle.com/javase/7/docs/api/");
+    classpath += files("build/generated/source/r/release")
+    options.links("http://docs.oracle.com/javase/7/docs/api/")
     destinationDir = file("../docs/")
     failOnError false
 }
@@ -107,54 +108,86 @@ artifacts {
     archives sourcesJar
 }
 
-install {
-    repositories {
-        mavenInstaller {
-            pom {
-                project {
-                    name project.group + ':' + project.archivesBaseName
-                    description 'Spotify authorization library for Android'
-                    url 'https://github.com/spotify/android-auth'
+signing {
+    sign configurations.archives
+}
 
-                    licenses {
-                        license {
-                            name 'The Apache Software License, Version 2.0'
-                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        }
-                    }
+project.ext["signing.keyId"] = ''
+project.ext["signing.password"] = ''
+project.ext["signing.secretKeyRingFile"] = ''
+project.ext["ossrhUsername"] = ''
+project.ext["ossrhPassword"] = ''
 
-                    scm {
-                        connection 'scm:git:https://github.com/spotify/android-auth.git'
-                        developerConnection 'scm:git:git@github.com:spotify/android-auth.git'
-                        url 'https://github.com/spotify/android-auth'
-                    }
-
-                    developers {
-                        developer {
-                            id 'erikg'
-                            name 'Erik Ghonyan'
-                            email 'erikg@spotify.com'
-                        }
-                    }
-                }
-            }
+def getSigningVariables() {
+    // Try to fetch the values from local.properties, otherwise look in the environment variables
+    // More info here: https://central.sonatype.org/publish/requirements/gpg/
+    File secretPropsFile = project.rootProject.file('local.properties')
+    if (secretPropsFile.exists()) {
+        Properties p = new Properties()
+        new FileInputStream(secretPropsFile).withCloseable { is ->
+            p.load(is)
         }
+        p.each { name, value ->
+            project.ext[name] = value
+        }
+    } else {
+        project.ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+        project.ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+        project.ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
+        project.ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+        project.ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
     }
 }
 
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
+/*
+    Deployment to OSSRH repository
+    1. run: ./gradlew uploadArchives
+    2. login to https://s01.oss.sonatype.org/ (you need to have access to auth lib OSSRH repository)
+    3. if everything looks correctly, close and then release the staging repository.
+    More info here: https://central.sonatype.org/publish/release/
+ */
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            getSigningVariables()
 
-    configurations = ['archives']
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-    pkg {
-        repo = 'maven'
-        name = 'android-auth'
-        userOrg = 'spotify'
+            repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: project.ext["ossrhUsername"], password: project.ext["ossrhPassword"])
+            }
 
-        version {
-            name = project.version
+            snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: project.ext["ossrhUsername"], password: project.ext["ossrhPassword"])
+            }
+
+            pom.project {
+                name project.group + ':' + project.archivesBaseName
+                packaging 'aar'
+                description 'Spotify authorization library for Android'
+                url 'https://github.com/spotify/android-auth'
+
+                licenses {
+                    license {
+                        name 'The Apache Software License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+
+                scm {
+                    connection 'scm:git:https://github.com/spotify/android-auth.git'
+                    developerConnection 'scm:git:git@github.com:spotify/android-auth.git'
+                    url 'https://github.com/spotify/android-auth'
+                }
+
+                developers {
+                    developer {
+                        id 'erikg'
+                        name 'Erik Ghonyan'
+                        email 'erikg@spotify.com'
+                    }
+                }
+            }
         }
     }
 }

--- a/auth-lib/build.gradle
+++ b/auth-lib/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 project.group = 'com.spotify.android'
 project.archivesBaseName = 'auth'
-project.version = '1.2.3'
+project.version = '1.2.4'
 
 android {
     compileSdkVersion 28

--- a/auth-sample/build.gradle
+++ b/auth-sample/build.gradle
@@ -67,7 +67,7 @@ android {
 
 dependencies {
 //    implementation files('../auth-lib/build/outputs/aar/auth-release.aar')
-    implementation 'com.spotify.android:auth:1.2.3'
+    implementation 'com.spotify.android:auth:1.2.4'
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
         google()
     }
@@ -29,13 +30,9 @@ buildscript {
     }
 }
 
-plugins {
-    id "com.jfrog.bintray" version "1.7.3"
-    id "com.github.dcendents.android-maven" version "1.4.1"
-}
-
 allprojects {
     repositories {
+        mavenCentral()
         jcenter()
         google()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
+signingEnabled=false
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
JCenter is sunsetting. To be able continue releasing new versions of auth lib after May 2021, we will now host the library on MavenCentral. This PR contains all necessary changes to `build.gradle` file and updates the README. We also needed to increase library version to be able to test if getting the library dependency from MavenCentral works.