### PR TITLE
Enable Sign in with Apple in WebViews

### DIFF
--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/webview/LoginDialog.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/webview/LoginDialog.java
@@ -62,7 +62,7 @@ public class LoginDialog extends Dialog {
      * RegEx describing which uris should be opened in the WebView.
      * When uri that is not whitelisted is received, the activity will finish.
      */
-    private static final String WEBVIEW_URIS = "^(.+\\.facebook\\.com)|(accounts\\.spotify\\.com)$";
+    private static final String WEBVIEW_URIS = "^(.+\\.facebook\\.com)|(accounts\\.spotify\\.com)|(.+\\.apple\\.com)$";
 
     private static final int DEFAULT_THEME = android.R.style.Theme_Translucent_NoTitleBar;
 


### PR DESCRIPTION
We need to allow list the Apple domain for the WebViews. 
Sign in with Google is not yet enabled as we have to change the whole webview login concept.