### PR TITLE
Explicitly specify Spotify app package names in auth library manifest

### DIFF
--- a/auth-lib/build.gradle
+++ b/auth-lib/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 project.group = 'com.spotify.android'
 project.archivesBaseName = 'auth'
-project.version = '1.2.5'
+project.version = '1.2.6'
 
 android {
     compileSdkVersion 30

--- a/auth-lib/src/main/AndroidManifest.xml
+++ b/auth-lib/src/main/AndroidManifest.xml
@@ -27,6 +27,11 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <queries>
+        <package android:name="com.spotify.music" />
+        <package android:name="com.spotify.music.debug" />
+        <package android:name="com.spotify.music.canary" />
+        <package android:name="com.spotify.music.partners" />
+
         <intent>
             <action android:name="com.spotify.sso.action.START_AUTH_FLOW" />
             <data android:mimeType="text/plain" />


### PR DESCRIPTION
**Changes:**
- Explicitly specify Spotify app package names in manifest to enable opening auth view on Android 11 devices - fix for https://github.com/spotify/android-sdk/issues/307
- Prepare for publishing new version