### PR TITLE
Fix LoginActivity launch mode

### DIFF
--- a/auth-lib/src/main/AndroidManifest.xml
+++ b/auth-lib/src/main/AndroidManifest.xml
@@ -46,7 +46,7 @@
         <activity
             android:name="com.spotify.sdk.android.auth.LoginActivity"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
-            android:launchMode="singleTop"
+            android:launchMode="singleInstance"
             android:exported="true">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
singleTop launch mode caused auth flow to not complete successfully in some cases.