### PR TITLE
Add delay when tabs close to prevent false report of user cancellation

### DIFF
--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/AuthorizationClient.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/AuthorizationClient.java
@@ -27,6 +27,8 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -496,7 +498,9 @@ public class AuthorizationClient {
                         .setType(AuthorizationResponse.Type.EMPTY)
                         .build();
 
-                sendComplete(authHandler, response);
+                new Handler(Looper.getMainLooper()).post((Runnable) () -> {
+                    sendComplete(authHandler, response);
+                });
             }
 
             @Override


### PR DESCRIPTION
Fixes [issue 235](https://github.com/spotify/android-sdk/issues/325).

The tab closure from the login dialog closing immediately proceeds the callback to `onNewIntent`. By debouncing the closure notification to the next iteration of the main looper, `onNewIntent` is able to callback first, avoiding the false report of user cancellation.