### PR TITLE
Attach utm parameters to the auth intent

### DIFF
--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/AuthorizationRequest.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/AuthorizationRequest.java
@@ -27,6 +27,9 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,8 +45,10 @@ public class AuthorizationRequest implements Parcelable {
     static final String ACCOUNTS_AUTHORITY = "accounts.spotify.com";
     static final String ACCOUNTS_PATH = "authorize";
     static final String SCOPES_SEPARATOR = " ";
-    static final String SPOTIFY_SDK = "spotify-sdk";
-    static final String ANDROID_SDK = "android-sdk";
+    @VisibleForTesting
+    public static final String SPOTIFY_SDK = "spotify-sdk";
+    @VisibleForTesting
+    public static final String ANDROID_SDK = "android-sdk";
 
     private final String mClientId;
     private final String mResponseType;
@@ -163,7 +168,14 @@ public class AuthorizationRequest implements Parcelable {
         return mCustomParams.get(key);
     }
 
+    @NonNull
     public String getCampaign() { return TextUtils.isEmpty(mCampaign) ? ANDROID_SDK : mCampaign; }
+
+    @NonNull
+    public String getSource() { return SPOTIFY_SDK; }
+
+    @NonNull
+    public String getMedium() { return ANDROID_SDK; }
 
     private AuthorizationRequest(String clientId,
                                  AuthorizationResponse.Type responseType,
@@ -193,8 +205,8 @@ public class AuthorizationRequest implements Parcelable {
                 .appendQueryParameter(AccountsQueryParameters.RESPONSE_TYPE, mResponseType)
                 .appendQueryParameter(AccountsQueryParameters.REDIRECT_URI, mRedirectUri)
                 .appendQueryParameter(AccountsQueryParameters.SHOW_DIALOG, String.valueOf(mShowDialog))
-                .appendQueryParameter(AccountsQueryParameters.UTM_SOURCE, SPOTIFY_SDK)
-                .appendQueryParameter(AccountsQueryParameters.UTM_MEDIUM, ANDROID_SDK)
+                .appendQueryParameter(AccountsQueryParameters.UTM_SOURCE, getSource())
+                .appendQueryParameter(AccountsQueryParameters.UTM_MEDIUM, getMedium())
                 .appendQueryParameter(AccountsQueryParameters.UTM_CAMPAIGN, getCampaign());
 
         if (mScopes != null && mScopes.length > 0) {

--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/IntentExtras.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/IntentExtras.java
@@ -10,6 +10,9 @@ public interface IntentExtras {
     String KEY_CLIENT_ID = "CLIENT_ID";
     String KEY_REQUESTED_SCOPES = "SCOPES";
     String KEY_STATE = "STATE";
+    String KEY_UTM_SOURCE = "UTM_SOURCE";
+    String KEY_UTM_MEDIUM = "UTM_MEDIUM";
+    String KEY_UTM_CAMPAIGN = "UTM_CAMPAIGN";
     String KEY_REDIRECT_URI = "REDIRECT_URI";
     String KEY_RESPONSE_TYPE = "RESPONSE_TYPE";
     String KEY_ACCESS_TOKEN = "ACCESS_TOKEN";

--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/app/SpotifyNativeAuthUtil.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/app/SpotifyNativeAuthUtil.java
@@ -26,6 +26,9 @@ import static com.spotify.sdk.android.auth.IntentExtras.KEY_REDIRECT_URI;
 import static com.spotify.sdk.android.auth.IntentExtras.KEY_REQUESTED_SCOPES;
 import static com.spotify.sdk.android.auth.IntentExtras.KEY_RESPONSE_TYPE;
 import static com.spotify.sdk.android.auth.IntentExtras.KEY_STATE;
+import static com.spotify.sdk.android.auth.IntentExtras.KEY_UTM_CAMPAIGN;
+import static com.spotify.sdk.android.auth.IntentExtras.KEY_UTM_MEDIUM;
+import static com.spotify.sdk.android.auth.IntentExtras.KEY_UTM_SOURCE;
 import static com.spotify.sdk.android.auth.IntentExtras.KEY_VERSION;
 
 import android.annotation.SuppressLint;
@@ -97,6 +100,9 @@ public class SpotifyNativeAuthUtil {
         intent.putExtra(KEY_RESPONSE_TYPE, mRequest.getResponseType());
         intent.putExtra(KEY_REQUESTED_SCOPES, mRequest.getScopes());
         intent.putExtra(KEY_STATE, mRequest.getState());
+        intent.putExtra(KEY_UTM_SOURCE, mRequest.getSource());
+        intent.putExtra(KEY_UTM_CAMPAIGN, mRequest.getCampaign());
+        intent.putExtra(KEY_UTM_MEDIUM, mRequest.getMedium());
 
         try {
             mContextActivity.startActivityForResult(intent, LoginActivity.REQUEST_CODE);

--- a/auth-lib/src/test/java/com/spotify/sdk/android/auth/AuthorizationClientTest.java
+++ b/auth-lib/src/test/java/com/spotify/sdk/android/auth/AuthorizationClientTest.java
@@ -80,10 +80,12 @@ public class AuthorizationClientTest {
 
     @Test
     public void createLoginActivityIntentShouldReturnAnIntentWithExtrasInIt() {
+        String campaign = "campaign";
         AuthorizationRequest authorizationRequest =
                 new AuthorizationRequest
                         .Builder("test", AuthorizationResponse.Type.TOKEN, "to://me")
                         .setScopes(new String[]{"testa", "toppen"})
+                        .setCampaign(campaign)
                         .build();
 
         Activity activity = mock(Activity.class);
@@ -98,6 +100,7 @@ public class AuthorizationClientTest {
         assertEquals("test", extra.getClientId());
         assertEquals("token", extra.getResponseType());
         assertEquals("to://me", extra.getRedirectUri());
+        assertEquals(campaign, extra.getCampaign());
         assertEquals(2, extra.getScopes().length);
     }
 


### PR DESCRIPTION
Pass utm parameters (utm_medium, utm_source, utm_campaign) to the Spotify auth intent