### PR TITLE
Use PKCE Code when token is requested

### DIFF
--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/AccountsQueryParameters.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/AccountsQueryParameters.java
@@ -14,4 +14,6 @@ public interface AccountsQueryParameters {
   String CODE = "code";
   String ACCESS_TOKEN = "access_token";
   String EXPIRES_IN = "expires_in";
+  String CODE_CHALLENGE = "code_challenge";
+  String CODE_CHALLENGE_METHOD = "code_challenge_method";
 }

--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/AuthorizationHandler.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/AuthorizationHandler.java
@@ -23,20 +23,21 @@ package com.spotify.sdk.android.auth;
 
 import android.app.Activity;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public interface AuthorizationHandler {
 
     interface OnCompleteListener {
-        void onComplete(AuthorizationResponse response);
+        void onComplete(@NonNull AuthorizationResponse response);
 
         void onCancel();
 
-        void onError(Throwable error);
+        void onError(@NonNull Throwable error);
 
     }
 
-    boolean start(Activity contextActivity, AuthorizationRequest request);
+    boolean start(@NonNull Activity contextActivity, @NonNull AuthorizationRequest request);
 
     void stop();
 

--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/AuthorizationResponse.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/AuthorizationResponse.java
@@ -25,6 +25,9 @@ import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 /**
  * An object that contains the parsed response from the Spotify authorization service.
  * To create one use {@link AuthorizationResponse.Builder} or
@@ -151,7 +154,7 @@ public class AuthorizationResponse implements Parcelable {
         mExpiresIn = expiresIn;
     }
 
-    public AuthorizationResponse(Parcel source) {
+    public AuthorizationResponse(@NonNull Parcel source) {
         mExpiresIn = source.readInt();
         mError = source.readString();
         mState = source.readString();
@@ -167,7 +170,8 @@ public class AuthorizationResponse implements Parcelable {
      * @return Authorization response. If parsing failed, this object will be populated with
      * the given error codes.
      */
-    public static AuthorizationResponse fromUri(Uri uri) {
+    @NonNull
+    public static AuthorizationResponse fromUri(@Nullable Uri uri) {
         AuthorizationResponse.Builder builder = new AuthorizationResponse.Builder();
         if (uri == null) {
             builder.setType(Type.EMPTY);
@@ -229,22 +233,27 @@ public class AuthorizationResponse implements Parcelable {
         return builder.build();
     }
 
+    @NonNull
     public Type getType() {
         return mType;
     }
 
+    @Nullable
     public String getCode() {
         return mCode;
     }
 
+    @Nullable
     public String getAccessToken() {
         return mAccessToken;
     }
 
+    @Nullable
     public String getState() {
         return mState;
     }
 
+    @Nullable
     public String getError() {
         return mError;
     }
@@ -259,7 +268,7 @@ public class AuthorizationResponse implements Parcelable {
     }
 
     @Override
-    public void writeToParcel(Parcel dest, int flags) {
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
         dest.writeInt(mExpiresIn);
         dest.writeString(mError);
         dest.writeString(mState);
@@ -270,11 +279,13 @@ public class AuthorizationResponse implements Parcelable {
 
     public static final Parcelable.Creator<AuthorizationResponse> CREATOR = new Parcelable.Creator<AuthorizationResponse>() {
         @Override
-        public AuthorizationResponse createFromParcel(Parcel source) {
+        @NonNull
+        public AuthorizationResponse createFromParcel(@NonNull Parcel source) {
             return new AuthorizationResponse(source);
         }
 
         @Override
+        @NonNull
         public AuthorizationResponse[] newArray(int size) {
             return new AuthorizationResponse[size];
         }

--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/IntentExtras.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/IntentExtras.java
@@ -18,6 +18,8 @@ public interface IntentExtras {
     String KEY_ACCESS_TOKEN = "ACCESS_TOKEN";
     String KEY_AUTHORIZATION_CODE = "AUTHORIZATION_CODE";
     String KEY_EXPIRES_IN = "EXPIRES_IN";
+    String KEY_CODE_CHALLENGE = "CODE_CHALLENGE";
+    String KEY_CODE_CHALLENGE_METHOD = "CODE_CHALLENGE_METHOD";
     /*
      * This is used to pass information about the protocol version
      * to the AuthorizationActivity.

--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/PKCEInformation.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/PKCEInformation.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2015-2016 Spotify AB
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.sdk.android.auth;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.Objects;
+
+public class PKCEInformation implements Parcelable {
+
+    private final String mVerifier;
+    private final String mChallenge;
+    private final String mCodeChallengeMethod;
+
+    private PKCEInformation(@NonNull String verifier, @NonNull String challenge, @NonNull String challengeMethod) {
+        mVerifier = verifier;
+        mChallenge = challenge;
+        mCodeChallengeMethod = challengeMethod;
+    }
+
+    @NonNull
+    public static PKCEInformation sha256(@NonNull String verifier, @NonNull String challenge) {
+        return new PKCEInformation(verifier, challenge, "S256");
+    }
+
+    @NonNull
+    public String getVerifier() {
+        return mVerifier;
+    }
+
+    @NonNull
+    public String getChallenge() {
+        return mChallenge;
+    }
+
+    @NonNull
+    public String getCodeChallengeMethod() {
+        return mCodeChallengeMethod;
+    }
+
+    private PKCEInformation(@NonNull Parcel in) {
+        mVerifier = in.readString();
+        mChallenge = in.readString();
+        mCodeChallengeMethod = in.readString();
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        dest.writeString(mVerifier);
+        dest.writeString(mChallenge);
+        dest.writeString(mCodeChallengeMethod);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<PKCEInformation> CREATOR = new Creator<PKCEInformation>() {
+        @Override
+        @NonNull
+        public PKCEInformation createFromParcel(@NonNull Parcel in) {
+            return new PKCEInformation(in);
+        }
+
+        @Override
+        @NonNull
+        public PKCEInformation[] newArray(int size) {
+            return new PKCEInformation[size];
+        }
+    };
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PKCEInformation that = (PKCEInformation) o;
+        return Objects.equals(mVerifier, that.mVerifier) &&
+                Objects.equals(mChallenge, that.mChallenge) &&
+                Objects.equals(mCodeChallengeMethod, that.mCodeChallengeMethod);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mVerifier, mChallenge, mCodeChallengeMethod);
+    }
+}

--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/PKCEInformationFactory.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/PKCEInformationFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015-2016 Spotify AB
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.sdk.android.auth;
+
+import android.util.Base64;
+
+import androidx.annotation.NonNull;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+public class PKCEInformationFactory {
+
+    private static final int CODE_VERIFIER_LENGTH = 128;
+    private static final String CODE_VERIFIER_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+
+    @NonNull
+    public static PKCEInformation create() throws NoSuchAlgorithmException {
+        String codeVerifier = generateCodeVerifier();
+        String codeChallenge = generateCodeChallenge(codeVerifier);
+        return PKCEInformation.sha256(codeVerifier, codeChallenge);
+    }
+
+    @NonNull
+    private static String generateCodeVerifier() {
+        SecureRandom secureRandom = new SecureRandom();
+        StringBuilder codeVerifier = new StringBuilder();
+
+        for (int i = 0; i < CODE_VERIFIER_LENGTH; i++) {
+            int randomIndex = secureRandom.nextInt(CODE_VERIFIER_CHARSET.length());
+            codeVerifier.append(CODE_VERIFIER_CHARSET.charAt(randomIndex));
+        }
+
+        return codeVerifier.toString();
+    }
+
+    @NonNull
+    private static String generateCodeChallenge(@NonNull String codeVerifier) throws NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+        return Base64.encodeToString(hash, Base64.URL_SAFE | Base64.NO_PADDING | Base64.NO_WRAP);
+    }
+}
+

--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/TokenExchangeRequest.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/TokenExchangeRequest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2015-2016 Spotify AB
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.sdk.android.auth;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A utility class for exchanging an authorization code for an access token using PKCE verifier.
+ * This implements the OAuth 2.0 Authorization Code Grant with PKCE as specified in RFC 7636.
+ */
+public class TokenExchangeRequest {
+
+    private static final String TOKEN_ENDPOINT = "https://accounts.spotify.com/api/token";
+    private static final String CONTENT_TYPE_FORM = "application/x-www-form-urlencoded";
+    private static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
+    private static final int TIMEOUT_MS = 10000; // 10 seconds
+
+    private final String mClientId;
+    private final String mCode;
+    private final String mRedirectUri;
+    private final String mCodeVerifier;
+
+    /**
+     * Creates a new token exchange request.
+     *
+     * @param clientId The client ID of the application
+     * @param code The authorization code received from the authorization server
+     * @param redirectUri The redirect URI used in the authorization request
+     * @param codeVerifier The PKCE code verifier that was used to generate the code challenge
+     */
+    public TokenExchangeRequest(@NonNull final String clientId,
+                               @NonNull final String code,
+                               @NonNull final String redirectUri,
+                               @NonNull final String codeVerifier) {
+        if (clientId == null || clientId.isEmpty()) {
+            throw new IllegalArgumentException("Client ID cannot be null or empty");
+        }
+        if (code == null || code.isEmpty()) {
+            throw new IllegalArgumentException("Authorization code cannot be null or empty");
+        }
+        if (redirectUri == null || redirectUri.isEmpty()) {
+            throw new IllegalArgumentException("Redirect URI cannot be null or empty");
+        }
+        if (codeVerifier == null || codeVerifier.isEmpty()) {
+            throw new IllegalArgumentException("Code verifier cannot be null or empty");
+        }
+
+        mClientId = clientId;
+        mCode = code;
+        mRedirectUri = redirectUri;
+        mCodeVerifier = codeVerifier;
+    }
+
+    /**
+     * Executes the token exchange request synchronously.
+     * This method performs a blocking HTTP request and should not be called on the main thread.
+     *
+     * @return TokenExchangeResponse containing the access token or error information
+     */
+    @NonNull
+    public TokenExchangeResponse execute() {
+        HttpURLConnection connection = null;
+        try {
+            final URL url = new URL(TOKEN_ENDPOINT);
+            connection = (HttpURLConnection) url.openConnection();
+
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", CONTENT_TYPE_FORM);
+            connection.setDoOutput(true);
+            connection.setConnectTimeout(TIMEOUT_MS);
+            connection.setReadTimeout(TIMEOUT_MS);
+
+            final String requestBody = buildRequestBody();
+
+            try (final OutputStream outputStream = connection.getOutputStream()) {
+                outputStream.write(requestBody.getBytes(StandardCharsets.UTF_8));
+                outputStream.flush();
+            }
+
+            final int responseCode = connection.getResponseCode();
+            final String responseBody = readResponse(connection, responseCode >= 400);
+
+            return TokenExchangeResponse.fromHttpResponse(responseCode, responseBody);
+
+        } catch (final IOException e) {
+            return TokenExchangeResponse.fromError("network_error", "Network error: " + e.getMessage());
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    @NonNull
+    private String buildRequestBody() {
+        try {
+            return "grant_type=" + URLEncoder.encode(GRANT_TYPE_AUTHORIZATION_CODE, "UTF-8") +
+                   "&client_id=" + URLEncoder.encode(mClientId, "UTF-8") +
+                   "&code=" + URLEncoder.encode(mCode, "UTF-8") +
+                   "&redirect_uri=" + URLEncoder.encode(mRedirectUri, "UTF-8") +
+                   "&code_verifier=" + URLEncoder.encode(mCodeVerifier, "UTF-8");
+        } catch (final Exception e) {
+            // This should never happen with UTF-8
+            throw new RuntimeException("Failed to encode request parameters", e);
+        }
+    }
+
+    @NonNull
+    private String readResponse(@NonNull final HttpURLConnection connection, final boolean isError) throws IOException {
+        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(
+                isError ? connection.getErrorStream() : connection.getInputStream(),
+                StandardCharsets.UTF_8))) {
+
+            final StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                response.append(line);
+            }
+
+            return response.toString();
+        }
+    }
+
+    /**
+     * Builder class for creating TokenExchangeRequest instances.
+     */
+    public static class Builder {
+        private String mClientId;
+        private String mCode;
+        private String mRedirectUri;
+        private String mCodeVerifier;
+
+        /**
+         * Sets the client ID.
+         *
+         * @param clientId The client ID
+         * @return This builder instance for method chaining
+         */
+        @NonNull
+        public Builder setClientId(@NonNull final String clientId) {
+            mClientId = clientId;
+            return this;
+        }
+
+        /**
+         * Sets the authorization code.
+         *
+         * @param code The authorization code
+         * @return This builder instance for method chaining
+         */
+        @NonNull
+        public Builder setCode(@NonNull final String code) {
+            mCode = code;
+            return this;
+        }
+
+        /**
+         * Sets the redirect URI.
+         *
+         * @param redirectUri The redirect URI
+         * @return This builder instance for method chaining
+         */
+        @NonNull
+        public Builder setRedirectUri(@NonNull final String redirectUri) {
+            mRedirectUri = redirectUri;
+            return this;
+        }
+
+        /**
+         * Sets the PKCE code verifier.
+         *
+         * @param codeVerifier The code verifier
+         * @return This builder instance for method chaining
+         */
+        @NonNull
+        public Builder setCodeVerifier(@NonNull final String codeVerifier) {
+            mCodeVerifier = codeVerifier;
+            return this;
+        }
+
+        /**
+         * Builds the TokenExchangeRequest.
+         *
+         * @return A new TokenExchangeRequest instance
+         * @throws IllegalArgumentException if any required field is null or empty
+         */
+        @NonNull
+        public TokenExchangeRequest build() {
+            return new TokenExchangeRequest(mClientId, mCode, mRedirectUri, mCodeVerifier);
+        }
+    }
+}
+

--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/TokenExchangeResponse.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/TokenExchangeResponse.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2015-2016 Spotify AB
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.sdk.android.auth;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Response from a token exchange request.
+ * Contains either the access token information or error details.
+ */
+public class TokenExchangeResponse {
+
+    private final boolean mIsSuccess;
+    private final String mAccessToken;
+    private final String mTokenType;
+    private final int mExpiresIn;
+    private final String mScope;
+    private final String mRefreshToken;
+    private final String mError;
+    private final String mErrorDescription;
+
+    private TokenExchangeResponse(final boolean isSuccess,
+                                 @Nullable final String accessToken,
+                                 @Nullable final String tokenType,
+                                 final int expiresIn,
+                                 @Nullable final String scope,
+                                 @Nullable final String refreshToken,
+                                 @Nullable final String error,
+                                 @Nullable final String errorDescription) {
+        mIsSuccess = isSuccess;
+        mAccessToken = accessToken;
+        mTokenType = tokenType;
+        mExpiresIn = expiresIn;
+        mScope = scope;
+        mRefreshToken = refreshToken;
+        mError = error;
+        mErrorDescription = errorDescription;
+    }
+
+    /**
+     * @return true if the token exchange was successful, false otherwise
+     */
+    public boolean isSuccess() {
+        return mIsSuccess;
+    }
+
+    /**
+     * @return the access token if successful, null otherwise
+     */
+    @Nullable
+    public String getAccessToken() {
+        return mAccessToken;
+    }
+
+    /**
+     * @return the token type (usually "Bearer") if successful, null otherwise
+     */
+    @Nullable
+    public String getTokenType() {
+        return mTokenType;
+    }
+
+    /**
+     * @return the number of seconds the access token is valid for, 0 if not provided or on error
+     */
+    public int getExpiresIn() {
+        return mExpiresIn;
+    }
+
+    /**
+     * @return the scope of the access token if provided, null otherwise
+     */
+    @Nullable
+    public String getScope() {
+        return mScope;
+    }
+
+    /**
+     * @return the refresh token if provided, null otherwise
+     */
+    @Nullable
+    public String getRefreshToken() {
+        return mRefreshToken;
+    }
+
+    /**
+     * @return the error code if the request failed, null if successful
+     */
+    @Nullable
+    public String getError() {
+        return mError;
+    }
+
+    /**
+     * @return the error description if the request failed, null if successful
+     */
+    @Nullable
+    public String getErrorDescription() {
+        return mErrorDescription;
+    }
+
+    /**
+     * Creates a TokenExchangeResponse from an HTTP response.
+     *
+     * @param responseCode The HTTP response code
+     * @param responseBody The response body as JSON string
+     * @return A TokenExchangeResponse instance
+     */
+    @NonNull
+    static TokenExchangeResponse fromHttpResponse(final int responseCode, @Nullable final String responseBody) {
+        if (responseBody == null || responseBody.trim().isEmpty()) {
+            return fromError("invalid_response", "Empty response body");
+        }
+
+        try {
+            final JSONObject json = new JSONObject(responseBody);
+
+            if (responseCode == 200) {
+                // Success response
+                final String accessToken = json.optString("access_token", null);
+                final String tokenType = json.optString("token_type", null);
+                final int expiresIn = json.optInt("expires_in", 0);
+                final String scope = json.optString("scope", null);
+                final String refreshToken = json.optString("refresh_token", null);
+
+                if (accessToken == null || accessToken.isEmpty()) {
+                    return fromError("invalid_response", "Missing access_token in response");
+                }
+
+                return fromSuccess(accessToken, tokenType, expiresIn, scope, refreshToken);
+            } else {
+                // Error response
+                final String error = json.optString("error", "unknown_error");
+                final String errorDescription = json.optString("error_description", null);
+                return fromError(error, errorDescription);
+            }
+        } catch (final JSONException e) {
+            return fromError("invalid_response", "Invalid JSON response: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Creates a successful TokenExchangeResponse.
+     *
+     * @param accessToken The access token
+     * @param tokenType The token type
+     * @param expiresIn The expiration time in seconds
+     * @param scope The token scope
+     * @param refreshToken The refresh token (optional)
+     * @return A successful TokenExchangeResponse
+     */
+    @NonNull
+    static TokenExchangeResponse fromSuccess(@NonNull final String accessToken,
+                                           @Nullable final String tokenType,
+                                           final int expiresIn,
+                                           @Nullable final String scope,
+                                           @Nullable final String refreshToken) {
+        return new TokenExchangeResponse(true, accessToken, tokenType, expiresIn, scope, refreshToken, null, null);
+    }
+
+    /**
+     * Creates an error TokenExchangeResponse.
+     *
+     * @param error The error code
+     * @param errorDescription The error description (optional)
+     * @return An error TokenExchangeResponse
+     */
+    @NonNull
+    static TokenExchangeResponse fromError(@NonNull final String error, @Nullable final String errorDescription) {
+        return new TokenExchangeResponse(false, null, null, 0, null, null, error, errorDescription);
+    }
+}
+

--- a/auth-lib/src/main/java/com/spotify/sdk/android/auth/app/Sha1HashUtil.java
+++ b/auth-lib/src/main/java/com/spotify/sdk/android/auth/app/Sha1HashUtil.java
@@ -1,17 +1,22 @@
 package com.spotify.sdk.android.auth.app;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 
 interface Sha1HashUtil {
-    String sha1Hash(String toHash);
+    @Nullable
+    String sha1Hash(@NonNull String toHash);
 }
 final class Sha1HashUtilImpl implements Sha1HashUtil {
 
     @Override
-    public String sha1Hash(String toHash) {
+    @Nullable
+    public String sha1Hash(@NonNull String toHash) {
         String hash = null;
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-1");
@@ -28,7 +33,8 @@ final class Sha1HashUtilImpl implements Sha1HashUtil {
 
     private final char[] HEX_ARRAY = "0123456789abcdef".toCharArray();
 
-    private String bytesToHex(byte[] bytes) {
+    @NonNull
+    private String bytesToHex(@NonNull byte[] bytes) {
         char[] hexChars = new char[bytes.length * 2];
         for (int j = 0; j < bytes.length; j++) {
             int v = bytes[j] & 0xFF;

--- a/auth-lib/src/test/java/com/spotify/sdk/android/auth/PKCEInformationFactoryTest.java
+++ b/auth-lib/src/test/java/com/spotify/sdk/android/auth/PKCEInformationFactoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015-2016 Spotify AB
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.sdk.android.auth;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.security.NoSuchAlgorithmException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class PKCEInformationFactoryTest {
+
+    @Test
+    public void shouldCreatePKCEInformation() throws NoSuchAlgorithmException {
+        PKCEInformation pkceInfo = PKCEInformationFactory.create();
+
+        assertNotNull(pkceInfo);
+        assertNotNull(pkceInfo.getVerifier());
+        assertNotNull(pkceInfo.getChallenge());
+        assertEquals("S256", pkceInfo.getCodeChallengeMethod());
+    }
+
+    @Test
+    public void shouldGenerateCodeVerifierWithCorrectLength() throws NoSuchAlgorithmException {
+        PKCEInformation pkceInfo = PKCEInformationFactory.create();
+
+        assertEquals(128, pkceInfo.getVerifier().length());
+    }
+
+    @Test
+    public void shouldGenerateUniqueCodeVerifiers() throws NoSuchAlgorithmException {
+        PKCEInformation pkceInfo1 = PKCEInformationFactory.create();
+        PKCEInformation pkceInfo2 = PKCEInformationFactory.create();
+
+        assertTrue(!pkceInfo1.getVerifier().equals(pkceInfo2.getVerifier()));
+        assertTrue(!pkceInfo1.getChallenge().equals(pkceInfo2.getChallenge()));
+    }
+
+    @Test
+    public void shouldGenerateValidBase64UrlEncodedChallenge() throws NoSuchAlgorithmException {
+        PKCEInformation pkceInfo = PKCEInformationFactory.create();
+
+        String challenge = pkceInfo.getChallenge();
+        assertTrue(challenge.matches("^[A-Za-z0-9_-]+$"));
+        assertTrue(!challenge.contains("="));
+        assertTrue(!challenge.contains("+"));
+        assertTrue(!challenge.contains("/"));
+    }
+}
+

--- a/auth-lib/src/test/java/com/spotify/sdk/android/auth/TokenExchangeRequestTest.java
+++ b/auth-lib/src/test/java/com/spotify/sdk/android/auth/TokenExchangeRequestTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2015-2016 Spotify AB
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.sdk.android.auth;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(RobolectricTestRunner.class)
+public class TokenExchangeRequestTest {
+
+    private static final String TEST_CLIENT_ID = "test_client_id";
+    private static final String TEST_CODE = "test_authorization_code";
+    private static final String TEST_REDIRECT_URI = "redirect://uri";
+    private static final String TEST_CODE_VERIFIER = "test_code_verifier_1234567890";
+
+    @Test
+    public void shouldCreateRequestWithValidParameters() {
+        final TokenExchangeRequest request = new TokenExchangeRequest(
+                TEST_CLIENT_ID,
+                TEST_CODE,
+                TEST_REDIRECT_URI,
+                TEST_CODE_VERIFIER
+        );
+
+        assertNotNull(request);
+    }
+
+    @Test
+    public void shouldCreateRequestUsingBuilder() {
+        final TokenExchangeRequest request = new TokenExchangeRequest.Builder()
+                .setClientId(TEST_CLIENT_ID)
+                .setCode(TEST_CODE)
+                .setRedirectUri(TEST_REDIRECT_URI)
+                .setCodeVerifier(TEST_CODE_VERIFIER)
+                .build();
+
+        assertNotNull(request);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWithNullClientId() {
+        new TokenExchangeRequest(null, TEST_CODE, TEST_REDIRECT_URI, TEST_CODE_VERIFIER);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWithEmptyClientId() {
+        new TokenExchangeRequest("", TEST_CODE, TEST_REDIRECT_URI, TEST_CODE_VERIFIER);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWithNullCode() {
+        new TokenExchangeRequest(TEST_CLIENT_ID, null, TEST_REDIRECT_URI, TEST_CODE_VERIFIER);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWithEmptyCode() {
+        new TokenExchangeRequest(TEST_CLIENT_ID, "", TEST_REDIRECT_URI, TEST_CODE_VERIFIER);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWithNullRedirectUri() {
+        new TokenExchangeRequest(TEST_CLIENT_ID, TEST_CODE, null, TEST_CODE_VERIFIER);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWithEmptyRedirectUri() {
+        new TokenExchangeRequest(TEST_CLIENT_ID, TEST_CODE, "", TEST_CODE_VERIFIER);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWithNullCodeVerifier() {
+        new TokenExchangeRequest(TEST_CLIENT_ID, TEST_CODE, TEST_REDIRECT_URI, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWithEmptyCodeVerifier() {
+        new TokenExchangeRequest(TEST_CLIENT_ID, TEST_CODE, TEST_REDIRECT_URI, "");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenBuilderMissingClientId() {
+        new TokenExchangeRequest.Builder()
+                .setCode(TEST_CODE)
+                .setRedirectUri(TEST_REDIRECT_URI)
+                .setCodeVerifier(TEST_CODE_VERIFIER)
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenBuilderMissingCode() {
+        new TokenExchangeRequest.Builder()
+                .setClientId(TEST_CLIENT_ID)
+                .setRedirectUri(TEST_REDIRECT_URI)
+                .setCodeVerifier(TEST_CODE_VERIFIER)
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenBuilderMissingRedirectUri() {
+        new TokenExchangeRequest.Builder()
+                .setClientId(TEST_CLIENT_ID)
+                .setCode(TEST_CODE)
+                .setCodeVerifier(TEST_CODE_VERIFIER)
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowWhenBuilderMissingCodeVerifier() {
+        new TokenExchangeRequest.Builder()
+                .setClientId(TEST_CLIENT_ID)
+                .setCode(TEST_CODE)
+                .setRedirectUri(TEST_REDIRECT_URI)
+                .build();
+    }
+}

--- a/auth-lib/src/test/java/com/spotify/sdk/android/auth/TokenExchangeResponseTest.java
+++ b/auth-lib/src/test/java/com/spotify/sdk/android/auth/TokenExchangeResponseTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2015-2016 Spotify AB
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.sdk.android.auth;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(RobolectricTestRunner.class)
+public class TokenExchangeResponseTest {
+
+    @Test
+    public void shouldParseSuccessfulResponse() {
+        final String responseBody = "{\"access_token\":\"test_access_token\"," +
+                "\"token_type\":\"Bearer\"," +
+                "\"expires_in\":3600," +
+                "\"scope\":\"user-read-private playlist-read\"," +
+                "\"refresh_token\":\"test_refresh_token\"}";
+
+        final TokenExchangeResponse response = TokenExchangeResponse.fromHttpResponse(200, responseBody);
+
+        assertTrue(response.isSuccess());
+        assertEquals("test_access_token", response.getAccessToken());
+        assertEquals("Bearer", response.getTokenType());
+        assertEquals(3600, response.getExpiresIn());
+        assertEquals("user-read-private playlist-read", response.getScope());
+        assertEquals("test_refresh_token", response.getRefreshToken());
+        assertNull(response.getError());
+        assertNull(response.getErrorDescription());
+    }
+
+    @Test
+    public void shouldParseSuccessfulResponseWithMinimalFields() {
+        final String responseBody = "{\"access_token\":\"test_access_token\"}";
+
+        final TokenExchangeResponse response = TokenExchangeResponse.fromHttpResponse(200, responseBody);
+
+        assertTrue(response.isSuccess());
+        assertEquals("test_access_token", response.getAccessToken());
+        assertNull(response.getTokenType());
+        assertEquals(0, response.getExpiresIn());
+        assertNull(response.getScope());
+        assertNull(response.getRefreshToken());
+        assertNull(response.getError());
+        assertNull(response.getErrorDescription());
+    }
+
+    @Test
+    public void shouldParseErrorResponse() {
+        final String responseBody = "{\"error\":\"invalid_grant\"," +
+                "\"error_description\":\"The provided authorization grant is invalid\"}";
+
+        final TokenExchangeResponse response = TokenExchangeResponse.fromHttpResponse(400, responseBody);
+
+        assertFalse(response.isSuccess());
+        assertNull(response.getAccessToken());
+        assertNull(response.getTokenType());
+        assertEquals(0, response.getExpiresIn());
+        assertNull(response.getScope());
+        assertNull(response.getRefreshToken());
+        assertEquals("invalid_grant", response.getError());
+        assertEquals("The provided authorization grant is invalid", response.getErrorDescription());
+    }
+
+    @Test
+    public void shouldParseErrorResponseWithMinimalFields() {
+        final String responseBody = "{\"error\":\"invalid_request\"}";
+
+        final TokenExchangeResponse response = TokenExchangeResponse.fromHttpResponse(400, responseBody);
+
+        assertFalse(response.isSuccess());
+        assertNull(response.getAccessToken());
+        assertEquals("invalid_request", response.getError());
+        assertNull(response.getErrorDescription());
+    }
+
+    @Test
+    public void shouldHandleEmptyResponseBody() {
+        final TokenExchangeResponse response = TokenExchangeResponse.fromHttpResponse(200, "");
+
+        assertFalse(response.isSuccess());
+        assertEquals("invalid_response", response.getError());
+        assertEquals("Empty response body", response.getErrorDescription());
+    }
+
+    @Test
+    public void shouldHandleNullResponseBody() {
+        final TokenExchangeResponse response = TokenExchangeResponse.fromHttpResponse(200, null);
+
+        assertFalse(response.isSuccess());
+        assertEquals("invalid_response", response.getError());
+        assertEquals("Empty response body", response.getErrorDescription());
+    }
+
+    @Test
+    public void shouldHandleInvalidJson() {
+        final String responseBody = "invalid json response";
+
+        final TokenExchangeResponse response = TokenExchangeResponse.fromHttpResponse(200, responseBody);
+
+        assertFalse(response.isSuccess());
+        assertEquals("invalid_response", response.getError());
+        assertTrue(response.getErrorDescription().startsWith("Invalid JSON response:"));
+    }
+
+    @Test
+    public void shouldHandleMissingAccessTokenInSuccessResponse() {
+        final String responseBody = "{\"token_type\":\"Bearer\",\"expires_in\":3600}";
+
+        final TokenExchangeResponse response = TokenExchangeResponse.fromHttpResponse(200, responseBody);
+
+        assertFalse(response.isSuccess());
+        assertEquals("invalid_response", response.getError());
+        assertEquals("Missing access_token in response", response.getErrorDescription());
+    }
+
+    @Test
+    public void shouldHandleEmptyAccessTokenInSuccessResponse() {
+        final String responseBody = "{\"access_token\":\"\",\"token_type\":\"Bearer\"}";
+
+        final TokenExchangeResponse response = TokenExchangeResponse.fromHttpResponse(200, responseBody);
+
+        assertFalse(response.isSuccess());
+        assertEquals("invalid_response", response.getError());
+        assertEquals("Missing access_token in response", response.getErrorDescription());
+    }
+
+    @Test
+    public void shouldHandleErrorResponseWithoutErrorField() {
+        final String responseBody = "{\"some_other_field\":\"value\"}";
+
+        final TokenExchangeResponse response = TokenExchangeResponse.fromHttpResponse(400, responseBody);
+
+        assertFalse(response.isSuccess());
+        assertEquals("unknown_error", response.getError());
+        assertNull(response.getErrorDescription());
+    }
+
+    @Test
+    public void shouldCreateSuccessResponseUsingFactoryMethod() {
+        final TokenExchangeResponse response = TokenExchangeResponse.fromSuccess(
+                "test_token", "Bearer", 3600, "user-read-private", "refresh_token");
+
+        assertTrue(response.isSuccess());
+        assertEquals("test_token", response.getAccessToken());
+        assertEquals("Bearer", response.getTokenType());
+        assertEquals(3600, response.getExpiresIn());
+        assertEquals("user-read-private", response.getScope());
+        assertEquals("refresh_token", response.getRefreshToken());
+        assertNull(response.getError());
+        assertNull(response.getErrorDescription());
+    }
+
+    @Test
+    public void shouldCreateErrorResponseUsingFactoryMethod() {
+        final TokenExchangeResponse response = TokenExchangeResponse.fromError(
+                "invalid_grant", "Grant is invalid");
+
+        assertFalse(response.isSuccess());
+        assertNull(response.getAccessToken());
+        assertEquals("invalid_grant", response.getError());
+        assertEquals("Grant is invalid", response.getErrorDescription());
+    }
+}
+

--- a/auth-lib/src/test/java/com/spotify/sdk/android/auth/app/SpotifyNativeAuthUtilTest.java
+++ b/auth-lib/src/test/java/com/spotify/sdk/android/auth/app/SpotifyNativeAuthUtilTest.java
@@ -7,6 +7,7 @@ import static junit.framework.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -28,6 +29,7 @@ import android.os.Build;
 import com.spotify.sdk.android.auth.AuthorizationRequest;
 import com.spotify.sdk.android.auth.AuthorizationResponse;
 import com.spotify.sdk.android.auth.IntentExtras;
+import com.spotify.sdk.android.auth.PKCEInformation;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -170,6 +172,65 @@ public class SpotifyNativeAuthUtilTest {
         assertEquals(campaign, intent.getStringExtra(IntentExtras.KEY_UTM_CAMPAIGN));
     }
 
+    @Test
+    public void shouldIncludePkceParametersInIntent() {
+        final String verifier = "test_verifier_1234567890";
+        final String challenge = "test_challenge_abcdef";
+        final PKCEInformation pkceInfo = PKCEInformation.sha256(verifier, challenge);
+        final Activity activity = mock(Activity.class);
+        Mockito.doNothing().when(activity).startActivityForResult(any(Intent.class), anyInt());
+        
+        final AuthorizationRequest authorizationRequest =
+                new AuthorizationRequest
+                        .Builder("test", AuthorizationResponse.Type.TOKEN, "to://me")
+                        .setScopes(new String[]{"testa", "toppen"})
+                        .setPkceInformation(pkceInfo)
+                        .build();
+        
+        configureMocksWithSigningInfo(activity);
+        final SpotifyNativeAuthUtil authUtil = new SpotifyNativeAuthUtil(
+                activity,
+                authorizationRequest,
+                new FakeSha1HashUtil(Collections.singletonMap(DEFAULT_TEST_SIGNATURE, SPOTIFY_HASH))
+        );
+        authUtil.startAuthActivity();
+
+        final ArgumentCaptor<Intent> captor = ArgumentCaptor.forClass(Intent.class);
+        verify(activity, times(1)).startActivityForResult(captor.capture(), anyInt());
+        final Intent intent = captor.getValue();
+
+        assertEquals(challenge, intent.getStringExtra(IntentExtras.KEY_CODE_CHALLENGE));
+        assertEquals("S256", intent.getStringExtra(IntentExtras.KEY_CODE_CHALLENGE_METHOD));
+    }
+
+    @Test
+    public void shouldNotIncludePkceParametersWhenNull() {
+        final Activity activity = mock(Activity.class);
+        Mockito.doNothing().when(activity).startActivityForResult(any(Intent.class), anyInt());
+        
+        final AuthorizationRequest authorizationRequest =
+                new AuthorizationRequest
+                        .Builder("test", AuthorizationResponse.Type.TOKEN, "to://me")
+                        .setScopes(new String[]{"testa", "toppen"})
+                        .setPkceInformation(null)
+                        .build();
+        
+        configureMocksWithSigningInfo(activity);
+        final SpotifyNativeAuthUtil authUtil = new SpotifyNativeAuthUtil(
+                activity,
+                authorizationRequest,
+                new FakeSha1HashUtil(Collections.singletonMap(DEFAULT_TEST_SIGNATURE, SPOTIFY_HASH))
+        );
+        authUtil.startAuthActivity();
+
+        final ArgumentCaptor<Intent> captor = ArgumentCaptor.forClass(Intent.class);
+        verify(activity, times(1)).startActivityForResult(captor.capture(), anyInt());
+        final Intent intent = captor.getValue();
+
+        assertEquals(null, intent.getStringExtra(IntentExtras.KEY_CODE_CHALLENGE));
+        assertEquals(null, intent.getStringExtra(IntentExtras.KEY_CODE_CHALLENGE_METHOD));
+    }
+
     private void configureDefaultMocks(Context mockedContext) {
         PackageInfo packageInfo = new PackageInfo();
         Signature mockedSignature = mock(Signature.class);
@@ -189,6 +250,96 @@ public class SpotifyNativeAuthUtilTest {
         configureMocks(mockedContext, packageInfo);
     }
 
+    @Test
+    @Config(sdk = Build.VERSION_CODES.O)
+    public void getSpotifyAppVersionCode_shouldReturnVersionCodeWhenValidSignature() {
+        Context mockedContext = mock(Context.class);
+        PackageInfo packageInfo = new PackageInfo();
+        packageInfo.versionCode = 87001234;
+        packageInfo.signatures = new Signature[1];
+        packageInfo.signatures[0] = new Signature("308204433082032ba003020102020900d7cb412f75f4887e300d06092a864886f70d01010b050030819d310b3009060355040613024e4c3110300e060355040813074e656d65696e65310e300c0603550407130541616c696d310f300d060355040a13064c696e67657231011300");
+
+        Sha1HashUtil mockedSha1HashUtil = mock(Sha1HashUtil.class);
+        when(mockedSha1HashUtil.sha1Hash(anyString())).thenReturn("25a9b2d2745c098361edaa3b87936dc29a28e7f1");
+
+        configureMocks(mockedContext, packageInfo);
+
+        assertEquals(87001234, SpotifyNativeAuthUtil.getSpotifyAppVersionCode(mockedContext, mockedSha1HashUtil));
+    }
+
+    @Test
+    public void getSpotifyAppVersionCode_shouldReturnMinusOneWhenInvalidSignature() {
+        Context mockedContext = mock(Context.class);
+        PackageInfo packageInfo = new PackageInfo();
+        packageInfo.versionCode = 87001234;
+        packageInfo.signatures = new Signature[1];
+        packageInfo.signatures[0] = new Signature("00112233445566778899aabbccddeeff00112233");
+
+        Sha1HashUtil mockedSha1HashUtil = mock(Sha1HashUtil.class);
+        when(mockedSha1HashUtil.sha1Hash(anyString())).thenReturn("invalid_hash");
+
+        configureMocks(mockedContext, packageInfo);
+
+        assertEquals(-1, SpotifyNativeAuthUtil.getSpotifyAppVersionCode(mockedContext, mockedSha1HashUtil));
+    }
+
+    @Test
+    public void getSpotifyAppVersionCode_shouldReturnMinusOneWhenAppNotInstalled() throws Exception {
+        Context mockedContext = mock(Context.class);
+        PackageManager mockedPackageManager = mock(PackageManager.class);
+        when(mockedContext.getPackageManager()).thenReturn(mockedPackageManager);
+        when(mockedPackageManager.getPackageInfo(anyString(), anyInt()))
+                .thenThrow(new PackageManager.NameNotFoundException());
+
+        Sha1HashUtil mockedSha1HashUtil = mock(Sha1HashUtil.class);
+
+        assertEquals(-1, SpotifyNativeAuthUtil.getSpotifyAppVersionCode(mockedContext, mockedSha1HashUtil));
+    }
+
+    @Test
+    @Config(sdk = Build.VERSION_CODES.O)
+    public void isSpotifyVersionAtLeast_shouldReturnTrueWhenVersionIsHigher() {
+        Context mockedContext = mock(Context.class);
+        PackageInfo packageInfo = new PackageInfo();
+        packageInfo.versionCode = 87001234;
+        packageInfo.signatures = new Signature[1];
+        packageInfo.signatures[0] = new Signature("308204433082032ba003020102020900d7cb412f75f4887e300d06092a864886f70d01010b050030819d310b3009060355040613024e4c3110300e060355040813074e656d65696e65310e300c0603550407130541616c696d310f300d060355040a13064c696e67657231011300");
+
+        Sha1HashUtil mockedSha1HashUtil = mock(Sha1HashUtil.class);
+        when(mockedSha1HashUtil.sha1Hash(anyString())).thenReturn("25a9b2d2745c098361edaa3b87936dc29a28e7f1");
+
+        configureMocks(mockedContext, packageInfo);
+
+        assertTrue(SpotifyNativeAuthUtil.isSpotifyVersionAtLeast(mockedContext, 87001000, mockedSha1HashUtil));
+    }
+
+    @Test
+    public void isSpotifyVersionAtLeast_shouldReturnFalseWhenVersionIsLower() {
+        Context mockedContext = mock(Context.class);
+        PackageInfo packageInfo = new PackageInfo();
+        packageInfo.versionCode = 87001000;
+        packageInfo.signatures = new Signature[1];
+        packageInfo.signatures[0] = new Signature("308204433082032ba003020102020900d7cb412f75f4887e300d06092a864886f70d01010b050030819d310b3009060355040613024e4c3110300e060355040813074e656d65696e65310e300c0603550407130541616c696d310f300d060355040a13064c696e67657231011300");
+
+        Sha1HashUtil mockedSha1HashUtil = mock(Sha1HashUtil.class);
+        when(mockedSha1HashUtil.sha1Hash(anyString())).thenReturn("25a9b2d2745c098361edaa3b87936dc29a28e7f1");
+
+        configureMocks(mockedContext, packageInfo);
+
+        assertFalse(SpotifyNativeAuthUtil.isSpotifyVersionAtLeast(mockedContext, 87002000));
+    }
+
+    @Test
+    public void isSpotifyVersionAtLeast_shouldReturnFalseWhenAppNotInstalled() throws Exception {
+        Context mockedContext = mock(Context.class);
+        PackageManager mockedPackageManager = mock(PackageManager.class);
+        when(mockedContext.getPackageManager()).thenReturn(mockedPackageManager);
+        when(mockedPackageManager.getPackageInfo(anyString(), anyInt()))
+                .thenThrow(new PackageManager.NameNotFoundException());
+
+        assertFalse(SpotifyNativeAuthUtil.isSpotifyVersionAtLeast(mockedContext, 87001000));
+    }
+
     private void configureMocks(Context mockedContext, PackageInfo packageInfo) {
         PackageManager mockedPackageManager = mock(PackageManager.class);
         when(mockedContext.getPackageManager()).thenReturn(mockedPackageManager);
@@ -200,7 +351,7 @@ public class SpotifyNativeAuthUtilTest {
         info.activityInfo.name = "";
         when(mockedPackageManager.resolveActivity(any(), anyInt())).thenReturn(info);
         try {
-            when(mockedPackageManager.getPackageInfo(eq(packageName), anyInt())).thenReturn(packageInfo);
+            when(mockedPackageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo);
         } catch (PackageManager.NameNotFoundException ignored) {
         }
     }

--- a/auth-lib/src/testAuth/java/com/spotify/sdk/android/auth/LoginActivityAuthTest.java
+++ b/auth-lib/src/testAuth/java/com/spotify/sdk/android/auth/LoginActivityAuthTest.java
@@ -53,7 +53,10 @@ public class LoginActivityAuthTest {
                 .create()
                 .get();
 
-        AuthorizationRequest request = new AuthorizationRequest.Builder("test", AuthorizationResponse.Type.TOKEN, "test://test").build();
+        PKCEInformation pkceInfo = PKCEInformation.sha256("test_verifier", "test_challenge");
+        AuthorizationRequest request = new AuthorizationRequest.Builder("test", AuthorizationResponse.Type.TOKEN, "test://test")
+                .setPkceInformation(pkceInfo)
+                .build();
         AuthorizationResponse response = new AuthorizationResponse.Builder()
                 .setType(AuthorizationResponse.Type.TOKEN)
                 .setAccessToken("test_token")

--- a/auth-sample/build.gradle
+++ b/auth-sample/build.gradle
@@ -68,8 +68,8 @@ android {
 }
 
 dependencies {
-//    implementation files('../auth-lib/build/outputs/aar/auth-release.aar')
-    implementation 'com.spotify.android:auth:2.1.1'
+    implementation files('../auth-lib/build/outputs/aar/auth-release.aar')
+//    implementation 'com.spotify.android:auth:2.1.1'
 
     implementation 'androidx.browser:browser:1.4.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'


### PR DESCRIPTION
It makes it so that we use PKCE in these cases:
- When the Spotify app is not installed (web fallback).
- When a PKCE enabled app is installed.

It will use the old and insecure token flow when:
- A Spotify app that is too old to support PKCE is installed.

PKCE support is added by doing this:
- We add Code Challenge and Code Challenge Method to the AuthorizationRequests (in the music app and sdk).
- Whenever an AuthorizationRequest is converted to and from a URI/Intent, we include the Code Challenge and Code Challenge Method.
- If the AuthorizationRequest we receive in AuthorizationClient (in the SDK), we generate PKCE information (verifier and challenge) before passing it to LoginActivity (in the SDK).
- If we receive an AuthorizationRequest in the LoginActivity for token we
    - Check that it has PKCE information attached to it, if not it’s an illegal state.
    - Convert it to a Code request before sending it to the Spotify app.
- When we receive a response for a code request in LoginActivity, we check if the originally received request was for Token. If it was, we exchange the code by sending a request to the backend with the code and the verifier.
