### PR TITLE
Ensure auth progress is stored on config changes

### DIFF
--- a/auth-lib/src/main/kotlin/com/spotify/sdk/android/auth/AuthorizationClient.kt
+++ b/auth-lib/src/main/kotlin/com/spotify/sdk/android/auth/AuthorizationClient.kt
@@ -297,15 +297,13 @@ class AuthorizationClient(
         authHandler?.stop()
     }
 
-    fun notifyInCaseUserCanceledAuth() {
-        if (currentHandler?.isAuthInProgress() == true) {
-            Log.i(TAG, "Spotify auth response: User cancelled")
-            val response = AuthorizationResponse.Builder()
-                .setType(AuthorizationResponse.Type.CANCELLED)
-                .build()
-            complete(response)
-        }
-    }
+    /**
+     * Returns true when a handler exists but has not yet entered the auth-in-progress state
+     * (e.g. Custom Tabs service binding is still in progress). In this case cancellation
+     * should be suppressed because the user hasn't actually seen the auth UI yet.
+     */
+    fun hasHandlerWithPendingAuth(): Boolean =
+        currentHandler != null && currentHandler?.isAuthInProgress() != true
 
     fun clearAuthInProgress() {
         if (currentHandler != null) {

--- a/auth-lib/src/main/kotlin/com/spotify/sdk/android/auth/LoginActivity.kt
+++ b/auth-lib/src/main/kotlin/com/spotify/sdk/android/auth/LoginActivity.kt
@@ -42,11 +42,14 @@ class LoginActivity : Activity(), AuthorizationClient.AuthorizationClientListene
     private val authorizationClient = AuthorizationClient(this)
     private val executorService: ExecutorService = Executors.newSingleThreadExecutor()
     private val mainHandler = Handler(Looper.getMainLooper())
+    private var authInProgress = false
 
     override fun onNewIntent(intent: Intent) {
         val originalRequest = getRequestFromIntent()
         super.onNewIntent(intent)
         val responseUri = intent.data
+
+        authInProgress = false
 
         // Clear auth-in-progress state to prevent onResume from thinking user canceled
         if (responseUri != null) {
@@ -96,7 +99,24 @@ class LoginActivity : Activity(), AuthorizationClient.AuthorizationClientListene
         } else if (savedInstanceState == null) {
             Log.d(TAG, String.format("Spotify Auth starting with the request [%s]", request.toUri().toString()))
             authorizationClient.authorize(request)
+            authInProgress = true
+        } else {
+            authInProgress = savedInstanceState.getBoolean(KEY_AUTH_IN_PROGRESS, false)
+            if (authInProgress) {
+                val responseUri = intent.data
+                if (responseUri != null) {
+                    authInProgress = false
+                    authorizationClient.clearAuthInProgress()
+                    val response = AuthorizationResponse.fromUri(responseUri)
+                    authorizationClient.complete(response)
+                }
+            }
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_AUTH_IN_PROGRESS, authInProgress)
     }
 
     private fun getRequestFromIntent(): AuthorizationRequest? {
@@ -106,10 +126,13 @@ class LoginActivity : Activity(), AuthorizationClient.AuthorizationClientListene
 
     override fun onResume() {
         super.onResume()
-        // onResume is called (except other cases) in the case
-        // of browser based auth flow when user pressed back/closed the Custom Tab and
-        // LoginActivity came to the foreground again.
-        authorizationClient.notifyInCaseUserCanceledAuth()
+        if (authInProgress && !authorizationClient.hasHandlerWithPendingAuth()) {
+            authInProgress = false
+            val response = AuthorizationResponse.Builder()
+                .setType(AuthorizationResponse.Type.CANCELLED)
+                .build()
+            authorizationClient.complete(response)
+        }
     }
 
     override fun onDestroy() {
@@ -122,6 +145,7 @@ class LoginActivity : Activity(), AuthorizationClient.AuthorizationClientListene
     @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
         super.onActivityResult(requestCode, resultCode, intent)
+        authInProgress = false
         if (requestCode == REQUEST_CODE) {
             val response = AuthorizationResponse.Builder()
 
@@ -290,6 +314,8 @@ class LoginActivity : Activity(), AuthorizationClient.AuthorizationClientListene
     }
 
     companion object {
+        private const val KEY_AUTH_IN_PROGRESS = "KEY_AUTH_IN_PROGRESS"
+
         const val EXTRA_REPLY = "REPLY"
         const val EXTRA_ERROR = "ERROR"
 

--- a/auth-lib/src/testAuth/java/com/spotify/sdk/android/auth/LoginActivityAuthTest.java
+++ b/auth-lib/src/testAuth/java/com/spotify/sdk/android/auth/LoginActivityAuthTest.java
@@ -29,6 +29,7 @@ import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 
 import com.spotify.sdk.android.auth.AuthorizationRequest;
@@ -124,6 +125,97 @@ public class LoginActivityAuthTest {
                 .build();
 
         assertCompletion(setup, response, Activity.RESULT_OK);
+    }
+
+    @Test
+    public void shouldDetectCancellationAfterRecreationWithoutResponse() {
+        Activity context = Robolectric.buildActivity(Activity.class).create().get();
+
+        PKCEInformation pkceInfo = PKCEInformation.sha256("test_verifier", "test_challenge");
+        AuthorizationRequest request = new AuthorizationRequest.Builder(
+                "test", AuthorizationResponse.Type.TOKEN, "test://test")
+                .setPkceInformation(pkceInfo)
+                .build();
+
+        Bundle requestBundle = new Bundle();
+        requestBundle.putParcelable(LoginActivity.REQUEST_KEY, request);
+
+        Intent intent = new Intent(context, LoginActivity.class);
+        intent.putExtra(LoginActivity.EXTRA_AUTH_REQUEST, requestBundle);
+
+        // Create and initialize the first activity (triggers authorize, sets authInProgress=true)
+        ActivityController<LoginActivity> controller = buildActivity(LoginActivity.class, intent);
+        shadowOf(controller.get()).setCallingActivity(context.getComponentName());
+        controller.create();
+
+        // Save instance state before "destruction"
+        Bundle savedState = new Bundle();
+        controller.saveInstanceState(savedState);
+
+        // Simulate recreation: new activity with same intent but no response URI
+        Intent recreatedIntent = new Intent(context, LoginActivity.class);
+        recreatedIntent.putExtra(LoginActivity.EXTRA_AUTH_REQUEST, requestBundle);
+
+        ActivityController<LoginActivity> controller2 = buildActivity(LoginActivity.class, recreatedIntent);
+        LoginActivity recreatedActivity = controller2.get();
+        ShadowActivity recreatedShadow = shadowOf(recreatedActivity);
+        recreatedShadow.setCallingActivity(context.getComponentName());
+        controller2.create(savedState).start().resume();
+
+        // onResume should detect authInProgress=true with no handler and deliver CANCELLED
+        assertTrue(recreatedActivity.isFinishing());
+        assertEquals(Activity.RESULT_CANCELED, recreatedShadow.getResultCode());
+        AuthorizationResponse response = recreatedShadow.getResultIntent()
+                .getBundleExtra(LoginActivity.EXTRA_AUTH_RESPONSE)
+                .getParcelable(LoginActivity.RESPONSE_KEY);
+        assertEquals(AuthorizationResponse.Type.CANCELLED, response.getType());
+    }
+
+    @Test
+    public void shouldProcessResponseInIntentDataAfterRecreation() {
+        Activity context = Robolectric.buildActivity(Activity.class).create().get();
+
+        PKCEInformation pkceInfo = PKCEInformation.sha256("test_verifier", "test_challenge");
+        AuthorizationRequest request = new AuthorizationRequest.Builder(
+                "test", AuthorizationResponse.Type.TOKEN, "test://test")
+                .setPkceInformation(pkceInfo)
+                .build();
+
+        Bundle requestBundle = new Bundle();
+        requestBundle.putParcelable(LoginActivity.REQUEST_KEY, request);
+
+        Intent intent = new Intent(context, LoginActivity.class);
+        intent.putExtra(LoginActivity.EXTRA_AUTH_REQUEST, requestBundle);
+
+        // Create and initialize the first activity
+        ActivityController<LoginActivity> controller = buildActivity(LoginActivity.class, intent);
+        shadowOf(controller.get()).setCallingActivity(context.getComponentName());
+        controller.create();
+
+        // Save instance state before "destruction"
+        Bundle savedState = new Bundle();
+        controller.saveInstanceState(savedState);
+
+        // Simulate recreation with a response URI in the intent
+        // (redirect arrived while activity was destroyed)
+        Intent recreatedIntent = new Intent(context, LoginActivity.class);
+        recreatedIntent.putExtra(LoginActivity.EXTRA_AUTH_REQUEST, requestBundle);
+        recreatedIntent.setData(Uri.parse("test://test?code=test_code"));
+
+        ActivityController<LoginActivity> controller2 = buildActivity(LoginActivity.class, recreatedIntent);
+        LoginActivity recreatedActivity = controller2.get();
+        ShadowActivity recreatedShadow = shadowOf(recreatedActivity);
+        recreatedShadow.setCallingActivity(context.getComponentName());
+        controller2.create(savedState);
+
+        // Response should be processed in onCreate, activity should finish with RESULT_OK
+        assertTrue(recreatedActivity.isFinishing());
+        assertEquals(Activity.RESULT_OK, recreatedShadow.getResultCode());
+        AuthorizationResponse response = recreatedShadow.getResultIntent()
+                .getBundleExtra(LoginActivity.EXTRA_AUTH_RESPONSE)
+                .getParcelable(LoginActivity.RESPONSE_KEY);
+        assertEquals(AuthorizationResponse.Type.CODE, response.getType());
+        assertEquals("test_code", response.getCode());
     }
 
 }


### PR DESCRIPTION
Before this change if you turned on "Do not keep activities" and pressed back from the consent screen, there would be a headless LoginActivity still running and you needed to press back again to get rid of it.