### PR TITLE
Bump setup-android action to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
## Summary
- Bump `android-actions/setup-android` from v3 to v4

## Why
v3's bundled `sdkmanager` (v16.0) fails on newer GitHub runner images with: Error on ZipFile unknown archive
v4 resolves this compatibility issue.