### PR TITLE
Fix Dokka 1.x compatibility with AGP 8.7.3

### DIFF
--- a/auth-lib/build.gradle.kts
+++ b/auth-lib/build.gradle.kts
@@ -200,11 +200,12 @@ afterEvaluate {
                 tasks.register(dokkaTaskName, DokkaTask::class.java) {
                     description = "Generates Dokka documentation for ${variant.name}."
 
-                    // Dokka 1.x crashes with AGP 8.7 when auto-discovering source sets
-                    // (NPE on androidTest sets). Clear and manually register.
+                    // Dokka 1.x NPEs on androidTest source sets with AGP 8.7+.
+                    // Clear auto-discovered sets and register only this variant.
                     @Suppress("DEPRECATION")
                     dokkaSourceSets.clear()
                     dokkaSourceSets.register(variant.name) {
+                        // Include both Kotlin and Java sources
                         variant.sourceSets.flatMap {
                             it.javaDirectories + it.kotlinDirectories
                         }.forEach { sourceDir ->
@@ -213,9 +214,11 @@ afterEvaluate {
                             }
                         }
 
+                        // Configure classpath
                         classpath.from(variant.javaCompileProvider.get().classpath)
                         classpath.from(project.files(android.bootClasspath.joinToString(File.pathSeparator)))
 
+                        // External documentation links
                         externalDocumentationLink {
                             url.set(uri("https://docs.oracle.com/javase/8/docs/api/").toURL())
                         }
@@ -223,6 +226,7 @@ afterEvaluate {
                             url.set(uri("https://developer.android.com/reference/").toURL())
                         }
 
+                        // Suppress warnings for undocumented code (optional)
                         suppressInheritedMembers.set(false)
                     }
 

--- a/auth-lib/build.gradle.kts
+++ b/auth-lib/build.gradle.kts
@@ -200,34 +200,30 @@ afterEvaluate {
                 tasks.register(dokkaTaskName, DokkaTask::class.java) {
                     description = "Generates Dokka documentation for ${variant.name}."
 
-                    // Configure source sets
-                    dokkaSourceSets {
-                        configureEach {
-                            // Include both Kotlin and Java sources
-                            val sourceDirs = variant.sourceSets.flatMap {
-                                it.javaDirectories
+                    // Dokka 1.x crashes with AGP 8.7 when auto-discovering source sets
+                    // (NPE on androidTest sets). Clear and manually register.
+                    @Suppress("DEPRECATION")
+                    dokkaSourceSets.clear()
+                    dokkaSourceSets.register(variant.name) {
+                        variant.sourceSets.flatMap {
+                            it.javaDirectories + it.kotlinDirectories
+                        }.forEach { sourceDir ->
+                            if (sourceDir.exists()) {
+                                sourceRoots.from(sourceDir)
                             }
-                            sourceDirs.forEach { sourceDir ->
-                                if (sourceDir.exists()) {
-                                    this@configureEach.sourceRoots.from(sourceDir)
-                                }
-                            }
-
-                            // Configure classpath
-                            classpath.from(variant.javaCompileProvider.get().classpath)
-                            classpath.from(project.files(android.bootClasspath.joinToString(File.pathSeparator)))
-
-                            // External documentation links
-                            externalDocumentationLink {
-                                url.set(uri("https://docs.oracle.com/javase/8/docs/api/").toURL())
-                            }
-                            externalDocumentationLink {
-                                url.set(uri("https://developer.android.com/reference/").toURL())
-                            }
-
-                            // Suppress warnings for undocumented code (optional)
-                            suppressInheritedMembers.set(false)
                         }
+
+                        classpath.from(variant.javaCompileProvider.get().classpath)
+                        classpath.from(project.files(android.bootClasspath.joinToString(File.pathSeparator)))
+
+                        externalDocumentationLink {
+                            url.set(uri("https://docs.oracle.com/javase/8/docs/api/").toURL())
+                        }
+                        externalDocumentationLink {
+                            url.set(uri("https://developer.android.com/reference/").toURL())
+                        }
+
+                        suppressInheritedMembers.set(false)
                     }
 
                     // Output directory

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.7.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.20")
     }
 }
 


### PR DESCRIPTION
## Summary
- Bump Dokka from 1.9.10 to 1.9.20
- Work around Dokka 1.x NPE when auto-discovering androidTest source sets on AGP 8.7+

## What changed
Dokka 1.x crashes with a `NullPointerException` when trying to create a `GradleDokkaSourceSetBuilder` for `androidTestAuthDebug` on AGP 8.7+. This is a [known Dokka 1.x limitation](https://github.com/Kotlin/dokka/issues/2518) — the auto-discovery of Android source sets calls AGP APIs that return `null` in newer AGP versions.

The fix clears the auto-discovered source sets and manually registers only the variant being documented. This preserves the existing per-flavor documentation (separate docs for `auth` and `store` artifacts).

Dokka 2.x was evaluated but doesn't support per-flavor documentation natively, which this project needs since the `auth` and `store` flavors expose different public classes.

## Test plan
- [x] `./gradlew :auth-lib:authReleaseDokka` succeeds
- [x] `./gradlew :auth-lib:storeReleaseDokka` succeeds
- [x] Full `./gradlew build` passes (290 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)